### PR TITLE
Add setting to skip checking if tables are innodb

### DIFF
--- a/plugin/Database/SqlSchema.php
+++ b/plugin/Database/SqlSchema.php
@@ -295,6 +295,10 @@ class SqlSchema
      */
     public function isInnodb($table)
     {
+        // Performance improvement: Skip checking innodb if you are sure your db is innodb only
+        if (defined('GLSR_FORCE_INNODB') && GLSR_FORCE_INNODB == true) {
+            return true;
+        }
         $engine = $this->db->get_var("
             SELECT ENGINE
             FROM INFORMATION_SCHEMA.TABLES


### PR DESCRIPTION
For some weird reason on some setups, to check if a table uses innoDB takes more time than selecting data from it. Now you can skip this check by adding a define('GLSR_FORCE_INNODB', true); to wp-config.php