### PR TITLE
Slack: Remove gaps from fields array

### DIFF
--- a/plugin/Modules/Slack.php
+++ b/plugin/Modules/Slack.php
@@ -118,7 +118,7 @@ class Slack
             $this->buildContentField(),
             $this->buildAuthorField(),
         ];
-        return array_filter($fields);
+        return array_values(array_filter($fields));
     }
 
     /**


### PR DESCRIPTION
The `array_filter` function may [leave gaps in the array](https://www.php.net/manual/en/function.array-filter.php#refsect1-function.array-filter-description
), and `json_encode` translates an array with gaps to an object, confusing the recipient.

    <?= json_encode(array_filter(["a", "b", ""])) ?>
    ["a","b"]
    <?= json_encode(array_filter(["a", "", "c"])) ?>
    {"0":"a","2":"c"}

Remove the gaps using the `array_values` function.

    <?= json_encode(array_values(array_filter(["a", "", "c"]))) ?>
    ["a","c"]